### PR TITLE
Changes for listing directories first and then files in media

### DIFF
--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -254,5 +254,7 @@ return [
                 'height'=> 500
            ],
        ]*/
+       // Show directories first and then files
+       'show_directory_first' => true,
     ],
 ];


### PR DESCRIPTION
Media Manager - Sort dir and files #5602

This branch contains the fix for the following issue.

https://github.com/the-control-group/voyager/issues/5602

The issue is files and directory are sorted by name together in the media manager. Now it is sorted like directories are listed first and the files.